### PR TITLE
Modifications needed to fix problems under Windows OS.

### DIFF
--- a/src/_h5ai/php/inc/Cache.php
+++ b/src/_h5ai/php/inc/Cache.php
@@ -16,7 +16,7 @@ class Cache {
 
     private function _name($key) {
 
-        return $this->dir . "/" . sha1($key);
+        return $this->dir . DIRECTORY_SEPARATOR . sha1($key);
     }
 
     public function get($key, $expiration = 3600) {

--- a/src/_h5ai/php/inc/Crumb.php
+++ b/src/_h5ai/php/inc/Crumb.php
@@ -9,9 +9,9 @@ class Crumb {
         $this->parts = array();
 
         $href = $h5ai->getAbsHref();
-        while ($href !== "/" && $href !== "//") {
+        while ($href !== "/") {
             $this->parts[] = $href;
-            $href = dirname($href) . "/";
+            $href = $this->h5ai->getParentHref($href);
         }
         $this->parts[] = "/";
 

--- a/src/_h5ai/php/inc/Customize.php
+++ b/src/_h5ai/php/inc/Customize.php
@@ -7,8 +7,8 @@ class Customize {
 
         $absPath = $h5ai->getAbsPath();
         $options = $h5ai->getOptions();
-        $this->customHeader = $absPath . "/" . $options["customHeader"];
-        $this->customFooter = $absPath . "/" . $options["customFooter"];
+        $this->customHeader = $absPath . DIRECTORY_SEPARATOR . $options["customHeader"];
+        $this->customFooter = $absPath . DIRECTORY_SEPARATOR . $options["customFooter"];
     }
 
     public function getHeader() {

--- a/src/_h5ai/php/inc/Extended.php
+++ b/src/_h5ai/php/inc/Extended.php
@@ -10,9 +10,9 @@ class Entry {
 
         $this->h5ai = $h5ai;
         $this->label = $label !== null ? $label : $this->h5ai->getLabel($absHref);
-        $this->absPath = $this->h5ai->normalizePath($absPath, false);
+        $this->absPath = $this->h5ai->normalizePath($absPath);
         $this->isFolder = is_dir($this->absPath);
-        $this->absHref = $this->h5ai->normalizePath($absHref, $this->isFolder);
+        $this->absHref = $this->h5ai->normalizeHref($absHref, $this->isFolder);
 
         $this->date = filemtime($this->absPath);
 
@@ -94,8 +94,8 @@ class Extended {
 
         if ($this->h5ai->getAbsHref() !== "/") {
             $options = $this->h5ai->getOptions();
-            $parentPath = dirname($this->h5ai->getAbsPath());
-            $parentHref = dirname($this->h5ai->getAbsHref());
+            $parentPath = $this->h5ai->getParentPath($this->h5ai->getAbsPath());
+            $parentHref = $this->h5ai->getParentHref($this->h5ai->getAbsHref());
             $label = $options["setParentFolderLabels"] === true ? $this->h5ai->getLabel($parentHref) : "<span class='l10n-parentDirectory'>Parent Directory</span>";
             $this->parent = new Entry($this->h5ai, $parentPath, $parentHref, "folder-parent", $label);
         }
@@ -104,7 +104,7 @@ class Extended {
 
         $files = $this->h5ai->readDir($this->h5ai->getAbsPath());
         foreach ($files as $file) {
-            $absPath = $this->h5ai->getAbsPath() . "/" . $file;
+            $absPath = $this->h5ai->getAbsPath() . DIRECTORY_SEPARATOR . $file;
             $absHref = $this->h5ai->getAbsHref() . rawurlencode($file);
             $this->content[$absPath] = new Entry($this->h5ai, $absPath, $absHref);
         }

--- a/src/_h5ai/php/inc/H5ai.php
+++ b/src/_h5ai/php/inc/H5ai.php
@@ -26,13 +26,13 @@ class H5ai {
         $this->types = $this->config["types"];
         $this->langs = $this->config["langs"];
 
-        $this->cache = new Cache($this->h5aiRoot . "/cache");
+        $this->cache = new Cache($this->h5aiRoot . DIRECTORY_SEPARATOR . "cache");
 
         $this->hrefRoot = $this->options["rootAbsHref"];
         $this->h5aiAbsHref = $this->options["h5aiAbsHref"];
         $this->domain = getenv("HTTP_HOST");
 
-        $this->absHref = $this->normalizePath(preg_replace('/\\?.*/', '', getenv("REQUEST_URI")), true);
+        $this->absHref = $this->normalizeHref(preg_replace('/\\?.*/', '', getenv("REQUEST_URI")), true);
         $this->absPath = $this->getAbsPath($this->absHref);
 
         $this->view = $this->options["viewmodes"][0];
@@ -131,7 +131,7 @@ class H5ai {
         //
         $endodedAbsHref = $this->hrefRoot . $endodedAbsHref;
 
-        return $this->normalizePath($endodedAbsHref, $endWithSlash);
+        return $this->normalizeHref($endodedAbsHref, $endWithSlash);
     }
 
     public function getAbsPath($absHref = null) {
@@ -143,7 +143,7 @@ class H5ai {
         //
         $absHref=substr($absHref, strlen($this->hrefRoot));
 
-        return $this->normalizePath($this->docRoot . "/" . rawurldecode($absHref), false);
+        return $this->normalizePath($this->docRoot . DIRECTORY_SEPARATOR . rawurldecode(str_replace('/' , DIRECTORY_SEPARATOR , $absHref)));
     }
 
     public function showThumbs() {
@@ -214,7 +214,32 @@ class H5ai {
         return $absHref === "/" ? $this->domain : rawurldecode(basename($absHref));
     }
 
-    public function normalizePath($path, $endWithSlash) {
+    public function getParentPath($path) {
+
+        return $this->getParentFolder($path, DIRECTORY_SEPARATOR);
+    }
+
+    public function getParentHref($href) {
+
+        return $this->getParentFolder($href, '/');
+    }
+
+    private function getParentFolder($subj, $sep) {
+
+        $preg_sep = ($sep === '/' ? '/' : '\\\\');
+        $preg_expr = '#^(.*' .$preg_sep. ')(.*' .$preg_sep. ')$#';
+        $preg_subj = ($this->endsWith($subj, $sep) ? $subj : $subj . $sep);
+        return preg_replace($preg_expr, '\1', $preg_subj);
+    }
+
+    public function normalizePath($path) {
+
+        $preg_sep = (DIRECTORY_SEPARATOR === '/' ? '/' : '\\\\');
+        $preg_expr = '#' .$preg_sep. '$#';
+        return ($path === DIRECTORY_SEPARATOR) ? DIRECTORY_SEPARATOR : preg_replace($preg_expr, '', $path);
+    }
+
+    public function normalizeHref($path, $endWithSlash) {
 
         return ($path === "/") ? "/" : (preg_replace('#/$#', '', $path) . ($endWithSlash ? "/" : ""));
     }

--- a/src/_h5ai/php/inc/Tree.php
+++ b/src/_h5ai/php/inc/Tree.php
@@ -8,9 +8,9 @@ class TreeEntry {
         $this->h5ai = $h5ai;
 
         $this->label = $this->h5ai->getLabel($absHref);
-        $this->absPath = $this->h5ai->normalizePath($absPath, false);
+        $this->absPath = $this->h5ai->normalizePath($absPath);
         $this->isFolder = is_dir($this->absPath);
-        $this->absHref = $this->h5ai->normalizePath($absHref, $this->isFolder);
+        $this->absHref = $this->h5ai->normalizeHref($absHref, $this->isFolder);
 
         $this->type = $type !== null ? $type : ($this->isFolder ? "folder" : $this->h5ai->getType($this->absPath));
         $this->content = null;
@@ -26,7 +26,7 @@ class TreeEntry {
 
         $files = $this->h5ai->readDir($this->absPath);
         foreach ($files as $file) {
-            $tree = new TreeEntry($this->h5ai, $this->absPath . "/" . $file, $this->absHref . rawurlencode($file));
+            $tree = new TreeEntry($this->h5ai, $this->absPath . DIRECTORY_SEPARATOR . $file, $this->absHref . rawurlencode($file));
 
             if ($tree->isFolder) {
                 $this->content[$tree->absPath] = $tree;
@@ -112,7 +112,7 @@ class TreeEntry {
             return $this;
         };
 
-        $tree = new TreeEntry($this->h5ai, dirname($this->absPath), dirname($this->absHref));
+        $tree = new TreeEntry($this->h5ai, $this->h5ai->getParentPath($this->absPath), $this->h5ai->getParentHref($this->absHref));
         $tree->loadContent();
         $tree->content[$this->absPath] = $this;
 

--- a/src/_h5ai/php/inc/ZipIt.php
+++ b/src/_h5ai/php/inc/ZipIt.php
@@ -18,7 +18,7 @@ class ZipIt {
         }
 
         foreach ($hrefs as $href) {
-            $d = dirname($href);
+            $d = $this->h5ai->getParentHref($href);
             $n = basename($href);
             if ($this->h5ai->getHttpCode($this->h5ai->getAbsHref($d)) === "h5ai" && !$this->h5ai->ignoreThisFile($n)) {
                 $localFile = $this->h5ai->getAbsPath($href);
@@ -48,8 +48,8 @@ class ZipIt {
             $zip->addEmptyDir($dir);
             $files = $this->h5ai->readDir($localDir);
             foreach ($files as $file) {
-                $localFile = $localDir . "/" . $file;
-                $file = $dir . "/" . $file;
+                $localFile = $localDir . DIRECTORY_SEPARATOR . $file;
+                $file = $dir . DIRECTORY_SEPARATOR . $file;
                 if (is_dir($localFile)) {
                     $this->zipDir($zip, $localFile, $file);
                 } else {


### PR DESCRIPTION
These changes fix problems due to the nature of dirname() on Windows and replaced "/" in paths for DIRECTORY_SEPARATOR.

Issues fixed: 
- Out of memory error on crumb.php due to infinite loop
- Max execution time exceeded problem on tree.php due to infinite loop
- Attempting to access directories outside of the document root in tree.php due to incorrect base path check (desired side effect from the previous issue fix)

Tested on: 
- Win7 x64, Apache 2.2.21 (apache lounge). PHP 5.3.8 (both mod_php and FastCGI)
- Ubuntu Linux (Desktop) 11.10 with the lamp tasksel package (Apache 2.2.20, PHP 5.3.6)
