### PR TITLE
Corrects PHP version inclusions

### DIFF
--- a/src/_h5ai/header.php
+++ b/src/_h5ai/header.php
@@ -3,7 +3,7 @@
 <!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
 <!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
-<?php include "php/main.php"; ?>
+<?php include(dirname(__FILE__) . '/php/main.php'); ?>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/src/_h5ai/php/api.php
+++ b/src/_h5ai/php/api.php
@@ -21,8 +21,8 @@ function checkKeys($keys) {
 list($action) = checkKeys(array("action"));
 
 
-require_once "config.php";
-require_once "inc/H5ai.php";
+require_once(dirname(__FILE__) . '/config.php');
+require_once(dirname(__FILE__) . '/inc/H5ai.php');
 $h5ai = new H5ai();
 $options = $h5ai->getOptions();
 
@@ -55,8 +55,8 @@ else if ($action === "thumb") {
     fail(0, "thumbs are disabled", !$options["showThumbs"]);
     list($srcAbsHref, $width, $height, $mode) = checkKeys(array("href", "width", "height", "mode"));
 
-    require_once "inc/Thumbnail.php";
-    require_once "inc/Image.php";
+    require_once(dirname(__FILE__) . '/inc/Thumbnail.php');
+    require_once(dirname(__FILE__) . '/inc/Image.php');
 
     $srcAbsPath = $h5ai->getDocRoot() . rawurldecode($srcAbsHref);
 
@@ -82,7 +82,7 @@ else if ($action === "tree") {
 
     list($href) = checkKeys(array("href"));
 
-    require_once "inc/Tree.php";
+    require_once(dirname(__FILE__) . '/inc/Tree.php');
 
     $absHref = trim($href);
     $absPath = $h5ai->getAbsPath($absHref);
@@ -99,7 +99,7 @@ else if ($action === "zip") {
     fail(0, "zipped download is disabled", !$options["zippedDownload"]);
     list($hrefs) = checkKeys(array("hrefs"));
 
-    require_once "inc/ZipIt.php";
+    require_once(dirname(__FILE__) . '/inc/ZipIt.php');
 
     $zipit = new ZipIt($h5ai);
 

--- a/src/_h5ai/php/inc/Extended.php
+++ b/src/_h5ai/php/inc/Extended.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Thumbnail.php";
+require_once(dirname(__FILE__) . '/Thumbnail.php');
 
 
 class Entry {

--- a/src/_h5ai/php/inc/H5ai.php
+++ b/src/_h5ai/php/inc/H5ai.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Cache.php";
+require_once(dirname(__FILE__) . '/Cache.php');
 
 class H5ai {
     private static $VIEWMODES = array("details", "icons");

--- a/src/_h5ai/php/inc/Thumbnail.php
+++ b/src/_h5ai/php/inc/Thumbnail.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Image.php";
+require_once(dirname(__FILE__) . '/Image.php');
 
 
 class Thumbnail {

--- a/src/_h5ai/php/main.php
+++ b/src/_h5ai/php/main.php
@@ -1,11 +1,11 @@
 <?php
 
-require_once "config.php";
-require_once "inc/H5ai.php";
-require_once "inc/Crumb.php";
-require_once "inc/Customize.php";
-require_once "inc/Extended.php";
-require_once "inc/Tree.php";
+require_once(dirname(__FILE__) . '/config.php');
+require_once(dirname(__FILE__) . '/inc/H5ai.php');
+require_once(dirname(__FILE__) . '/inc/Crumb.php');
+require_once(dirname(__FILE__) . '/inc/Customize.php');
+require_once(dirname(__FILE__) . '/inc/Extended.php');
+require_once(dirname(__FILE__) . '/inc/Tree.php');
 
 $h5ai = new H5ai();
 $crumb = new Crumb($h5ai);


### PR DESCRIPTION
The current PHP scripts `include` and `require` others with the assumption that all relative paths will be computed relatively to the root h5ai header file. This is not the case when listing directories other than the root. This commit fixes that behavior by “absoluting” relative paths relatively to the including file, with `dirname(__FILE__)`.
