### PR TITLE
Disable foldersize calculation by default

### DIFF
--- a/src/_h5ai/conf/options.json
+++ b/src/_h5ai/conf/options.json
@@ -137,7 +137,7 @@ Options
 	Calc the size of folders.
 	*/
 	"foldersize": {
-		"enabled": true
+		"enabled": false
 	},
 
 	/*


### PR DESCRIPTION
I am running http://ftp.ntou.edu.tw and I found this option could increase I/O and hangs system on a mirror site.

I suggest turning it off by default.

BTW, you enabled some options in commit b8503b6, is it intended to make these changes?
