### PR TITLE
Optimized for integration via iframe

### DIFF
--- a/src/_h5ai/client/js/inc/ext/tree.js
+++ b/src/_h5ai/client/js/inc/ext/tree.js
@@ -31,6 +31,8 @@ modulejs.define('ext/tree', ['_', '$', 'core/settings', 'core/resource', 'core/e
 				.data('item', item);
 
 			location.setLink($a, item);
+			if(!item.isManaged) $a.attr('target', '_parent');
+
 			$img.attr('src', resource.image('folder'));
 			$label.text(item.label);
 

--- a/src/_h5ai/client/js/inc/view/items.js
+++ b/src/_h5ai/client/js/inc/view/items.js
@@ -50,6 +50,7 @@ modulejs.define('view/items', ['_', '$', 'core/settings', 'core/resource', 'core
 				.data('item', item);
 
 			location.setLink($a, item);
+			if(!item.isManaged) $a.attr('target', '_parent');
 
 			$iconImg.attr('src', resource.icon(item.type)).attr('alt', item.type);
 			$label.text(item.label);


### PR DESCRIPTION
In an iframe, when you click on a folder, containing for example a php file, the web page is launched within the iframe, it is not necessarily a desired effect, it is necessary to specify with target = "_parent" for the link to be launched in the tab, not the iframe

There need to modify other files?

Sorry for my english very bad.
