### PR TITLE
Special case the naming of archives based on a single selection.

### DIFF
--- a/src/_h5ai/client/js/inc/ext/download.js
+++ b/src/_h5ai/client/js/inc/ext/download.js
@@ -29,9 +29,17 @@ modulejs.define('ext/download', ['_', '$', 'core/settings', 'core/resource', 'co
 
         var type = settings.type;
         var extension = (type === 'shell-zip') ? 'zip' : 'tar';
+
+        var name;
+        if (selectedItems.length === 1) {
+            name = selectedItems[0].label;
+        } else {
+            name = settings.packageName || location.getItem().label;
+        }
+
         var query = {
                 action: 'download',
-                as: (settings.packageName || location.getItem().label) + '.' + extension,
+                as: name + '.' + extension,
                 type: type,
                 hrefs: _.pluck(selectedItems, 'absHref').join('|:|')
             };

--- a/src/_h5ai/client/js/inc/ext/download.js
+++ b/src/_h5ai/client/js/inc/ext/download.js
@@ -34,12 +34,12 @@ modulejs.define('ext/download', ['_', '$', 'core/settings', 'core/resource', 'co
         if (selectedItems.length === 1) {
             name = selectedItems[0].label;
         } else {
-            name = settings.packageName || location.getItem().label;
+            name = location.getItem().label;
         }
 
         var query = {
                 action: 'download',
-                as: name + '.' + extension,
+                as: (settings.packageName || name) + '.' + extension,
                 type: type,
                 hrefs: _.pluck(selectedItems, 'absHref').join('|:|')
             };

--- a/src/_h5ai/conf/options.json
+++ b/src/_h5ai/conf/options.json
@@ -84,7 +84,7 @@ Options
     To select files the "select"-extension needs to be enabled.
 
     - type: "php-tar", "shell-tar" or "shell-zip"
-    - packageName: basename of the download package, null for current foldername
+    - packageName: basename of the download package, null for current filename or foldername
     - alwaysVisible: always show download button (defaults to download the current folder)
     */
     "download": {


### PR DESCRIPTION
I hope this is the proper way to suggest a change. I'm brand new to this.

When downloading a file or folder the archives name was based on the enclosing directory. This makes sense unless you are downloading exactly one thing. In that case it makes sense to inherit the name from the downloaded item. This turned out to be a fairly trivial change.