### PR TITLE
CR2 previews work when registering them as “img-jpg”.

### DIFF
--- a/src/_h5ai/conf/types.json
+++ b/src/_h5ai/conf/types.json
@@ -29,7 +29,7 @@ File types mapped to file extensions
     "img-bmp":          ["*.bmp"],
     "img-gif":          ["*.gif"],
     "img-ico":          ["*.ico"],
-    "img-jpg":          ["*.jpg", "*.jpeg"],
+    "img-jpg":          ["*.jpg", "*.jpeg", "*.CR2"],
     "img-png":          ["*.png"],
     "img-tiff":         ["*.tiff"],
     "txt":              ["*.text", "*.txt"],


### PR DESCRIPTION
In reference to https://github.com/lrsjng/h5ai/issues/308, I can get CR2 images to show thumbnails if I add their extension to the "img-jpg" image type.