### PR TITLE
Major Speed Improvements with Folder Size Calculations

### DIFF
--- a/src/_h5ai/conf/options.json
+++ b/src/_h5ai/conf/options.json
@@ -109,15 +109,16 @@ Options
 
     /*
     Calc the size of folders.
-    This operation is real slow. The calculated sizes differ slightly for both
-    calculation types since "php" only adds the file size, while "shell-du"
-    also adds the sizes for the actual folder files.
+    This operation is very fast with "shell-du" and is very slow with "php".
+    The calculated sizes differ slightly for both calculation types since "php"
+    only adds the file size, while "shell-du" also adds the sizes for the
+    actual folder files.
 
-    - type: "php" (sloooow) or "shell-du" (sloow)
+    - type: "shell-du" (fast) or "php" (sloooow)
     */
     "foldersize": {
         "enabled": false,
-        "type": "php"
+        "type": "shell-du"
     },
 
     /*

--- a/src/_h5ai/conf/options.json
+++ b/src/_h5ai/conf/options.json
@@ -114,11 +114,18 @@ Options
     only adds the file size, while "shell-du" also adds the sizes for the
     actual folder files.
 
+    Folder Size caching is recommended for sites with folders that contain large numbers of sub folders.
+    A minimum of 3 seconds is highly recommended to prevent double calculations on initial page load.
+
     - type: "shell-du" (fast) or "php" (sloooow)
+    - cacheEnabled: "true" or "false". Requires write access to "/_{{pkg.name}}/cache" folder
+    - cacheMaxAge: [seconds] A folder's sub folder sizes expire and refresh after this time
     */
     "foldersize": {
         "enabled": false,
-        "type": "shell-du"
+        "type": "shell-du",
+        "cacheEnabled": true,
+        "cacheMaxAge": 60
     },
 
     /*

--- a/src/_h5ai/server/php/inc/class-app.php
+++ b/src/_h5ai/server/php/inc/class-app.php
@@ -174,8 +174,10 @@ class App {
         // return $this->get_all_items();
         // return json_decode(file_get_contents(CACHE_PATH . "/item.json"));
 
+        $requestPath = $this->to_path($url);
+
         $cache = array();
-        $folder = Item::get($this, $this->to_path($url), $cache);
+        $folder = Item::get($this, $requestPath, $cache);
 
         // add content of subfolders
         if ($what >= 2 && $folder !== null) {
@@ -193,7 +195,32 @@ class App {
 
         uasort($cache, array("Item", "cmp"));
         $result = array();
+
+        // Get file/folder sizes of immediate children of $requestPath
+        $fastSetFolderSizes = ($this->options["foldersize"]["enabled"] &&
+                                $this->options["foldersize"]["type"] === "shell-du" &&
+                                HAS_CMD_DU);
+        $folderSizes = array();
+        if ($fastSetFolderSizes) {
+            $stdoutLine = array();
+            exec("du -sk $requestPath/*/", $stdoutLine);  // trailing slash gets folders only
+            foreach ($stdoutLine as $line) {
+                // $line is bites separated by tab then full path (with trailing slash) i.e. "1024  /var/www/folder1/"
+                $lineParts = explode("\t", $line);
+
+                // add filesize to array with its path as the key
+                $folderSizes[$lineParts[1]] = intval($lineParts[0], 10) * 1024;
+            }
+        }
+
         foreach ($cache as $p => $item) {
+            // set folder size
+            if ($fastSetFolderSizes && $item->is_folder) { // check for folder to avoid case where a folder and file both share the same name
+                $itemPath = $item->path . '/'; // trailing slash needed to match folder name
+                if (isset($folderSizes[$itemPath])) {
+                    $item->size = $folderSizes[$itemPath];
+                }
+            }
             $result[] = $item->to_json_object();
         }
 

--- a/src/_h5ai/server/php/inc/class-app.php
+++ b/src/_h5ai/server/php/inc/class-app.php
@@ -196,31 +196,9 @@ class App {
         uasort($cache, array("Item", "cmp"));
         $result = array();
 
-        // Get file/folder sizes of immediate children of $requestPath
-        $fastSetFolderSizes = ($this->options["foldersize"]["enabled"] &&
-                                $this->options["foldersize"]["type"] === "shell-du" &&
-                                HAS_CMD_DU);
-        $folderSizes = array();
-        if ($fastSetFolderSizes) {
-            $stdoutLine = array();
-            exec("du -sk $requestPath/*/", $stdoutLine);  // trailing slash gets folders only
-            foreach ($stdoutLine as $line) {
-                // $line is bites separated by tab then full path (with trailing slash) i.e. "1024  /var/www/folder1/"
-                $lineParts = explode("\t", $line);
-
-                // add filesize to array with its path as the key
-                $folderSizes[$lineParts[1]] = intval($lineParts[0], 10) * 1024;
-            }
-        }
+        Item::set_fast_child_folder_sizes($this, $requestPath, $cache);
 
         foreach ($cache as $p => $item) {
-            // set folder size
-            if ($fastSetFolderSizes && $item->is_folder) { // check for folder to avoid case where a folder and file both share the same name
-                $itemPath = $item->path . '/'; // trailing slash needed to match folder name
-                if (isset($folderSizes[$itemPath])) {
-                    $item->size = $folderSizes[$itemPath];
-                }
-            }
             $result[] = $item->to_json_object();
         }
 

--- a/src/_h5ai/server/php/inc/class-item.php
+++ b/src/_h5ai/server/php/inc/class-item.php
@@ -2,6 +2,8 @@
 
 class Item {
 
+    private static $FOLDER_SIZE_CACHE = "folder-sizes";
+
     public static function cmp($item1, $item2) {
 
         if ($item1->is_folder && !$item2->is_folder) {
@@ -31,6 +33,77 @@ class Item {
             $cache[$path] = $item;
         }
         return $item;
+    }
+
+
+    // Conditions permitting, uses Linux du command to quickly set all of $path's child folder sizes
+    public static function set_fast_child_folder_sizes($app, $path, &$cache) {
+
+        $options = $app->get_options();
+        if (!(HAS_CMD_DU && $options["foldersize"]["enabled"] && $options["foldersize"]["type"] === "shell-du"
+              && is_array($cache) && sizeof($cache))) {
+            return;
+        }
+
+        $sizes_cache_folder_path = CACHE_PATH . "/" . Item::$FOLDER_SIZE_CACHE;
+
+        if (!is_dir($sizes_cache_folder_path)) {
+            @mkdir($sizes_cache_folder_path, 0755, true);
+        }
+
+
+        $path_hash = sha1($path);
+        $folder_sizes = array();
+        $cache_enabled = $options["foldersize"]["cacheEnabled"] && HAS_WRITABLE_CACHE;
+        $cache_max_age = intval($options["foldersize"]["cacheMaxAge"]);
+        $now = time();
+        $cache_expired = true;
+
+        // read folder sizes from cache if enabled and not expired
+        $sizes_cache_file_path = $sizes_cache_folder_path . "/folder-sizes-$path_hash.json";
+        if ($cache_enabled && file_exists($sizes_cache_file_path)) {
+            $data = json_decode(file_get_contents($sizes_cache_file_path),true);
+            if (isset($data['items']) && isset($data['created'])) {
+                $created = intval($data['created']);
+                $age = $now-$created;
+                if ($now - $created > $cache_max_age) {
+                    unlink($sizes_cache_file_path);
+                } else {
+                    $cache_expired = false;
+                    $folder_sizes = $data['items'];
+                }
+            }
+        }
+
+        if (!sizeof($folder_sizes)) {
+            $du_lines = array();
+            exec("du -sk $path/*/", $du_lines);  // trailing slash gets folders only
+            foreach ($du_lines as $du_line) {
+                // $line is bites separated by tab then full path (with trailing slash) i.e. "1024  /var/www/folder1/"
+                $line_parts = explode("\t", $du_line);
+
+                // add filesize to array with its path as the key
+                $folder_sizes[$line_parts[1]] = intval($line_parts[0], 10) * 1024;
+            }
+        }
+
+        if ($cache_enabled && $cache_expired && sizeof($folder_sizes)) {
+            @file_put_contents($sizes_cache_file_path, json_encode(array(
+                'created' => time(),
+                'items' => $folder_sizes
+            )));
+        }
+
+
+        // set folder size
+        foreach($cache as $item) {
+            if ($item->is_folder) { // check for folder to avoid case where a folder and file both share the same name
+                $itemPath = $item->path . '/'; // trailing slash needed to match folder name
+                if (isset($folder_sizes[$itemPath])) {
+                    $item->size = $folder_sizes[$itemPath];
+                }
+            }
+        }
     }
 
 

--- a/src/_h5ai/server/php/inc/class-util.php
+++ b/src/_h5ai/server/php/inc/class-util.php
@@ -159,15 +159,10 @@ class Util {
         } else if (is_dir($path)) {
 
             $options = $app->get_options();
-            if ($options["foldersize"]["enabled"]) {
-                if (HAS_CMD_DU && $options["foldersize"]["type"] === "shell-du") {
-                    $cmdv = array("du", "-sk", $path);
-                    $size = intval(preg_replace("#\s.*$#", "", Util::exec_cmdv($cmdv)), 10) * 1024;
-                } else {
-                    $size = 0;
-                    foreach ($app->read_dir($path) as $name) {
-                        $size += Util::filesize($app, $path . "/" . $name);
-                    }
+            if ($options["foldersize"]["enabled"] && $options["foldersize"]["type"] === "php") {
+                $size = 0;
+                foreach ($app->read_dir($path) as $name) {
+                    $size += Util::filesize($app, $path . "/" . $name);
                 }
             }
         }


### PR DESCRIPTION
Overhauled the folder size calculations.  Tested on a 15.8GB folder with 1631 sub folders, and page load time improved from 56s to 5s (91% faster).

---

Folder size calculations are now extremely fast and leverage one Linux "du" operation for all folders
instead of multiple "du" operations for every folder listed.

Changed the default foldersize setting from "php" to "shell-du"
Modified the foldersize description to indicate "shell-du" is fast

Removed shell-du folder size checking for individual folders.
shell-du will only check all folder sizes in one operation.
