### PR TITLE
Added checkboxes selection without mouse option.

### DIFF
--- a/src/_h5ai/client/js/inc/ext/select.js
+++ b/src/_h5ai/client/js/inc/ext/select.js
@@ -2,6 +2,7 @@ modulejs.define('ext/select', ['_', '$', 'core/settings', 'core/resource', 'core
 
     var settings = _.extend({
             enabled: false,
+            mouse: false,
             checkboxes: false
         }, allsettings.select);
     var template = '<span class="selector"><img src="' + resource.image('selected') + '" alt="selected"/></span>';
@@ -184,20 +185,22 @@ modulejs.define('ext/select', ['_', '$', 'core/settings', 'core/resource', 'core
 
     function init() {
 
-        if (!settings.enabled) {
+        if (!settings.enabled || (!settings.mouse && !settings.checkboxes)) {
             return;
         }
-
-        $selectionRect.hide().appendTo('body');
 
         event.sub('location.changed', onLocationChanged);
         event.sub('location.refreshed', onLocationRefreshed);
 
-        // $document
-        $('#content')
-            .on('mousedown', '.noSelection', noSelection)
-            .on('mousedown', '.noSelectionUnlessCtrl,input,select,a', noSelectionUnlessCtrl)
-            .on('mousedown', selectionStart);
+        if (settings.mouse) {
+            $selectionRect.hide().appendTo('body');
+
+            // $document
+            $('#content')
+                .on('mousedown', '.noSelection', noSelection)
+                .on('mousedown', '.noSelectionUnlessCtrl,input,select,a', noSelectionUnlessCtrl)
+                .on('mousedown', selectionStart);
+        }
     }
 
 

--- a/src/_h5ai/conf/options.json
+++ b/src/_h5ai/conf/options.json
@@ -257,13 +257,15 @@ Options
     },
 
     /*
-    Make entries selectable (first mouse button + drag).
+    Make entries selectable.
     At the moment only needed for packaged download.
 
+    - mouse: boolean, allow first mouse button + drag selection
     - checkboxes: boolean, show a checkbox on mouse over item
     */
     "select": {
         "enabled": true,
+        "mouse": true,
         "checkboxes": true
     },
 


### PR DESCRIPTION
I love the way you can select files, but I wanted the user to be able to select header text as well.
Added an option in options.json files allowing to keep the checkboxes selection but to disable the mouse drag selection.