### PR TITLE
Add new “shown” option to create exceptions for hidden items

### DIFF
--- a/src/_h5ai/server/php/inc/class-app.php
+++ b/src/_h5ai/server/php/inc/class-app.php
@@ -103,6 +103,13 @@ class App {
             return true;
         }
 
+        foreach ($this->options["view"]["shown"] as $re) {
+            $re = App::$RE_DELIMITER . str_replace(App::$RE_DELIMITER, '\\' . App::$RE_DELIMITER, $re) . App::$RE_DELIMITER;
+            if (preg_match($re, $name)) {
+                return false;
+            }
+        }
+
         foreach ($this->options["view"]["hidden"] as $re) {
             $re = App::$RE_DELIMITER . str_replace(App::$RE_DELIMITER, '\\' . App::$RE_DELIMITER, $re) . App::$RE_DELIMITER;
             if (preg_match($re, $name)) {


### PR DESCRIPTION
Can be used to unhide subitems in some hidden top folder, for example.