### PR TITLE
The Allow, Deny, and Order directives, provided by mod_access_compat, are deprecated and will go away in a future version. You should avoid using them, and avoid outdated tutorials recommending their use.

### DIFF
--- a/src/_h5ai/.htaccess
+++ b/src/_h5ai/.htaccess
@@ -1,3 +1,1 @@
-Satisfy all
-Order deny,allow
-Deny from all
+Require all denied

--- a/src/_h5ai/private/.htaccess
+++ b/src/_h5ai/private/.htaccess
@@ -1,3 +1,1 @@
-Satisfy all
-Order deny,allow
-Deny from all
+Require all denied

--- a/src/_h5ai/public/.htaccess
+++ b/src/_h5ai/public/.htaccess
@@ -1,6 +1,4 @@
-Satisfy all
-Order allow,deny
-Allow from all
+Require all granted
 
 DirectoryIndex disabled
 


### PR DESCRIPTION
https://httpd.apache.org/docs/2.4/upgrading.html#run-time
https://httpd.apache.org/docs/current/howto/access.html#host