### PR TITLE
fixed downloading of current folder ("alwaysVisible"-download)

### DIFF
--- a/src/_h5ai/public/js/lib/ext/download.js
+++ b/src/_h5ai/public/js/lib/ext/download.js
@@ -39,7 +39,8 @@ modulejs.define('ext/download', ['_', '$', 'core/event', 'core/location', 'core/
             action: 'download',
             as: name + '.' + extension,
             type: type,
-            baseHref: location.getAbsHref()
+            baseHref: location.getAbsHref(),
+            hrefs: ''
         };
 
         _.each(selectedItems, function (item, idx) {


### PR DESCRIPTION
When enabling "alwaysVisible" download and clicking the button without having anything selected, hrefs is not defined in the query which causes a "missing parameter" json-error page to come up instead of the download.
That patch is quite simple, but should do the trick.