### PR TITLE
Use mod_authz_core when available. Otherwise, fallback to mod_authz_host or mod_access_compat.

### DIFF
--- a/src/_h5ai/.htaccess
+++ b/src/_h5ai/.htaccess
@@ -1,3 +1,10 @@
-Satisfy all
-Order deny,allow
-Deny from all
+<IfModule mod_authz_core.c>
+    #Apache 2.4
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    #Apache 2.2
+    Satisfy all
+    Order deny,allow
+    Deny from all
+</IfModule>

--- a/src/_h5ai/private/.htaccess
+++ b/src/_h5ai/private/.htaccess
@@ -1,3 +1,0 @@
-Satisfy all
-Order deny,allow
-Deny from all

--- a/src/_h5ai/public/.htaccess
+++ b/src/_h5ai/public/.htaccess
@@ -1,6 +1,13 @@
-Satisfy all
-Order allow,deny
-Allow from all
+<IfModule mod_authz_core.c>
+    #Apache 2.4
+    Require all granted
+</IfModule>
+<IfModule !mod_authz_core.c>
+    #Apache 2.2
+    Satisfy all
+    Order allow,deny
+    Allow from all
+</IfModule>
 
 DirectoryIndex disabled
 


### PR DESCRIPTION
This properly supports both Apache 2.4 and 2.2.

See:
https://github.com/lrsjng/h5ai/pull/489
https://github.com/lrsjng/h5ai/issues/504