### PR TITLE
Add a notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In short you have to take the following two steps:
 
 * place folder `_h5ai` in the document root folder of the web server
 * append `/_h5ai/public/index.php` to the end of the default index-file list
-
+* make sure the php function `exec` and `passthru` are not disabled by `disable_functions` in `php.ini` if you want to enalbe the optional features such as "shell zip","shell tar" and "shell du"
 
 ## Build
 


### PR DESCRIPTION
A notice of how to enable the optional features.

I used to be annoyed by this problem for a long time because I tried to test again and again by different options of php, nginx and also h5ai itself. But I still cannot download packaged folders by "shell zip". The reason I choose h5ai is not only the beautiful interface but also the powerful functions, especially the multi-file download function.

Finally, I find out the right options but the process really makes me upset and tired. So I want to add this to notice others to let them be able to enable these functions directly.