### PR TITLE
reduce the minimum required version of php to support CentOS 7

### DIFF
--- a/src/_h5ai/public/index.php
+++ b/src/_h5ai/public/index.php
@@ -1,7 +1,7 @@
 <?php
 
 define('H5AI_VERSION', '{{VERSION}}');
-define('MIN_PHP_VERSION', '5.5.0');
+define('MIN_PHP_VERSION', '5.4.16');
 
 if (!function_exists('version_compare') || version_compare(PHP_VERSION, MIN_PHP_VERSION, '<')) {
     header('Content-type: text/plain;charset=utf-8');


### PR DESCRIPTION
PHP version shipped with CentOS 7 is 5.4.16

Ref: #601 