### PR TITLE
Fix Invalid argument supplied for foreach() in class-archive.php:138

### DIFF
--- a/src/_h5ai/private/php/ext/class-archive.php
+++ b/src/_h5ai/private/php/ext/class-archive.php
@@ -135,6 +135,9 @@ class Archive {
     }
 
     private function add_hrefs($hrefs) {
+        if(!is_array($hrefs)){
+            $hrefs=array($hrefs);
+        }
         foreach ($hrefs as $href) {
             if (trim($href) === '') {
                 continue;


### PR DESCRIPTION
Before this change, when trying to download a folder oder single file via the download (nginx/php7.1-fpm) option I get below error.

```
[error] 22294#22294: *1376 FastCGI sent in stderr: "PHP message: PHP Warning:  Invalid argument supplied for foreach() in ..._h5ai/private/php/ext/class-archive.php on line 138
PHP message: PHP Stack trace:
PHP message: PHP   1. {main}() ..._h5ai/public/index.php:0
PHP message: PHP   2. Bootstrap::run() /..._h5ai/public/index.php:17
PHP message: PHP   3. Api->apply() /..._h5ai/private/php/class-bootstrap.php:19
PHP message: PHP   4. Api->on_download() /..._h5ai/private/php/core/class-api.php:20
PHP message: PHP   5. Archive->output() /..._h5ai/private/php/core/class-api.php:37
PHP message: PHP   6. Archive->add_hrefs() /..._h5ai/private/php/ext/class-archive.php:28" while reading response header from upstream, 
client: 10.0.2.2, server: localhost.dev, request: "POST /downloads/? HTTP/1.1",
upstream: "fastcgi://127.0.0.1:9000", host: "localhost.dev:28888", referrer: "http://localhost.dev:28888/downloads/"
```