### PR TITLE
Stop searching for header/footer files at web root

### DIFF
--- a/src/_h5ai/private/conf/options.json
+++ b/src/_h5ai/private/conf/options.json
@@ -108,9 +108,14 @@
     Note the different filenames: "header" (only current) - "headers" (current and sub directories)!
     The file's content will be placed inside a <div/> tag above/below the main content.
     If a file's extension is ".md" instead of ".html" its content will be interpreted as markdown.
+
+    - stopSearchingAtRoot: boolean, only search for header and footer files until the web root
+        directory. if `false`, will search for header/footer up the entire directory structure,
+        even above the web root
     */
     "custom": {
-        "enabled": true
+        "enabled": true,
+        "stopSearchingAtRoot": true
     },
 
     /*

--- a/src/_h5ai/private/php/ext/class-custom.php
+++ b/src/_h5ai/private/php/ext/class-custom.php
@@ -54,6 +54,14 @@ class Custom {
             if ($parent_path === $path) {
                 break;
             }
+
+            // Stop once we reach the root
+            if (
+                $this->context->query_option('custom.stopSearchingAtRoot', true) &&
+                $path === $this->context->get_setup()->get('ROOT_PATH')
+            ) {
+                break;
+            }
             $path = $parent_path;
         }
 


### PR DESCRIPTION
Adds an option to stop searching for header/footer files once we hit the web root (`ROOT_PATH`), to avoid traversing too far up the directory structure, particularly when `open_basedir` is enabled (as it currently throws errors)

Closes https://github.com/lrsjng/h5ai/issues/669