### PR TITLE
Allow options to be customized per directory

### DIFF
--- a/src/_h5ai/private/php/ext/class-custom.php
+++ b/src/_h5ai/private/php/ext/class-custom.php
@@ -21,11 +21,42 @@ class Custom {
         }
     }
 
+    /**
+     * Load custom options for the specified path. Traverses the directory structure to include
+     * options for all parent directories too. Options in children will override the options
+     * inherited from their ancestors.
+     *
+     * @param $href string
+     * @return array<mixed>
+     */
+    private function get_options(string $href) {
+        if (!$this->context->query_option('custom.enabled', false)) {
+            return [];
+        }
+
+        $file_prefix = $this->context->get_setup()->get('FILE_PREFIX');
+        $root_path = $this->context->get_setup()->get('ROOT_PATH');
+
+        // Find all options files, from the current path all the way to the root
+        $option_files = [];
+        $path = $this->context->to_path($href);
+        do {
+            $file = $path . '/' . $file_prefix . '.options.json';
+            if (is_readable($file)) {
+                $option_files[] = Json::load($file);
+            }
+            $path = Util::normalize_path(dirname($path));
+        } while ($path !== $root_path && $path !== '/' && $href !== '/');
+
+        return count($option_files) === 0 ? [] : array_merge(...array_reverse($option_files));
+    }
+
     public function get_customizations($href) {
         if (!$this->context->query_option('custom.enabled', false)) {
             return [
                 'header' => ['content' => null, 'type' => null],
-                'footer' => ['content' => null, 'type' => null]
+                'footer' => ['content' => null, 'type' => null],
+                'options' => [],
             ];
         }
 
@@ -59,7 +90,8 @@ class Custom {
 
         return [
             'header' => ['content' => $header, 'type' => $header_type],
-            'footer' => ['content' => $footer, 'type' => $footer_type]
+            'footer' => ['content' => $footer, 'type' => $footer_type],
+            'options' => self::get_options($href),
         ];
     }
 }

--- a/src/_h5ai/private/php/ext/class-custom.php
+++ b/src/_h5ai/private/php/ext/class-custom.php
@@ -56,7 +56,7 @@ class Custom {
             return [
                 'header' => ['content' => null, 'type' => null],
                 'footer' => ['content' => null, 'type' => null],
-                'options' => [],
+                'options' => (object)[],
             ];
         }
 
@@ -91,7 +91,7 @@ class Custom {
         return [
             'header' => ['content' => $header, 'type' => $header_type],
             'footer' => ['content' => $footer, 'type' => $footer_type],
-            'options' => self::get_options($href),
+            'options' => (object)self::get_options($href),
         ];
     }
 }

--- a/src/_h5ai/public/js/lib/ext/custom.js
+++ b/src/_h5ai/public/js/lib/ext/custom.js
@@ -27,6 +27,7 @@ const onLocationChanged = item => {
     server.request({action: 'get', custom: item.absHref}).then(response => {
         const data = response && response.custom;
         each(['header', 'footer'], key => update(data, key));
+        event.pub('custom.optionsLoaded', data.options);
     });
 };
 

--- a/src/_h5ai/public/js/lib/view/view.js
+++ b/src/_h5ai/public/js/lib/view/view.js
@@ -86,15 +86,15 @@ const addCssStyles = () => {
     dom('<style></style>').text(styles.join('\n')).appTo('head');
 };
 
-const set = (mode, size) => {
-    const stored = store.get(storekey);
+const getModes = () => checkedModes;
+const getMode = () => store.get(storekey) && store.get(storekey).mode || settings.modes[0];
 
-    mode = mode || stored && stored.mode;
-    size = size || stored && stored.size;
-    mode = includes(settings.modes, mode) ? mode : settings.modes[0];
-    size = includes(settings.sizes, size) ? size : settings.sizes[0];
-    store.put(storekey, {mode, size});
+const getSizes = () => sortedSizes;
+const getSize = () => store.get(storekey) && store.get(storekey).size || settings.sizes[0];
 
+const updateView = () => {
+    const mode = getMode();
+    const size = getSize();
     each(checkedModes, m => {
         if (m === mode) {
             $view.addCls('view-' + m);
@@ -114,12 +114,27 @@ const set = (mode, size) => {
     event.pub('view.mode.changed', mode, size);
 };
 
-const getModes = () => checkedModes;
-const getMode = () => store.get(storekey).mode;
-const setMode = mode => set(mode, null);
+const set = (mode, size) => {
+    const stored = store.get(storekey);
 
-const getSizes = () => sortedSizes;
-const getSize = () => store.get(storekey).size;
+    mode = mode || stored && stored.mode;
+    size = size || stored && stored.size;
+    mode = includes(settings.modes, mode) ? mode : settings.modes[0];
+    size = includes(settings.sizes, size) ? size : settings.sizes[0];
+
+    // Unset if it's being set back to the default value
+    if (mode === settings.modes[0]) {
+        mode = undefined;
+    }
+    if (size === settings.sizes[0]) {
+        size = undefined;
+    }
+
+    store.put(storekey, {mode, size});
+    updateView();
+};
+
+const setMode = mode => set(mode, null);
 const setSize = size => set(null, size);
 
 const onMouseenter = ev => {
@@ -260,7 +275,7 @@ const onResize = () => {
 
 const init = () => {
     addCssStyles();
-    set();
+    updateView();
 
     $view.appTo(base.$content);
     $hint.hide();

--- a/src/_h5ai/public/js/lib/view/view.js
+++ b/src/_h5ai/public/js/lib/view/view.js
@@ -18,6 +18,7 @@ const settings = Object.assign({
     setParentFolderLabels: false,
     sizes
 }, allsettings.view);
+let folderSettings = null;
 const sortedSizes = settings.sizes.sort((a, b) => a - b);
 const checkedModes = intersection(settings.modes, modes);
 const storekey = 'view';
@@ -87,10 +88,16 @@ const addCssStyles = () => {
 };
 
 const getModes = () => checkedModes;
-const getMode = () => store.get(storekey) && store.get(storekey).mode || settings.modes[0];
+const getMode = () =>
+    (folderSettings && folderSettings.mode) ||
+    (store.get(storekey) && store.get(storekey).mode) ||
+    settings.modes[0];
 
 const getSizes = () => sortedSizes;
-const getSize = () => store.get(storekey) && store.get(storekey).size || settings.sizes[0];
+const getSize = () =>
+    (folderSettings && folderSettings.size) ||
+    (store.get(storekey) && store.get(storekey).size) ||
+    settings.sizes[0];
 
 const updateView = () => {
     const mode = getMode();
@@ -273,6 +280,11 @@ const onResize = () => {
     }
 };
 
+const onCustomOptionsLoaded = options => {
+    folderSettings = options && options.view;
+    updateView();
+};
+
 const init = () => {
     addCssStyles();
     updateView();
@@ -285,6 +297,7 @@ const init = () => {
     event.sub('location.changed', onLocationChanged);
     event.sub('location.refreshed', onLocationRefreshed);
     event.sub('resize', onResize);
+    event.sub('custom.optionsLoaded', onCustomOptionsLoaded);
     onResize();
 };
 

--- a/src/_h5ai/public/js/lib/view/view.js
+++ b/src/_h5ai/public/js/lib/view/view.js
@@ -87,17 +87,28 @@ const addCssStyles = () => {
     dom('<style></style>').text(styles.join('\n')).appTo('head');
 };
 
+// Gets the first truthy value in `candidates` that is also listed in `validOptions`
+const findFirstValid = (candidates, validOptions) => candidates.find(x => x && includes(validOptions, x));
+
 const getModes = () => checkedModes;
-const getMode = () =>
-    (folderSettings && folderSettings.mode) ||
-    (store.get(storekey) && store.get(storekey).mode) ||
-    settings.modes[0];
+const getMode = () => findFirstValid(
+    [
+        (store.get(storekey) && store.get(storekey).mode),
+        (folderSettings && folderSettings.mode),
+        settings.modes[0]
+    ],
+    settings.modes
+);
 
 const getSizes = () => sortedSizes;
-const getSize = () =>
-    (folderSettings && folderSettings.size) ||
-    (store.get(storekey) && store.get(storekey).size) ||
-    settings.sizes[0];
+const getSize = () => findFirstValid(
+    [
+        (store.get(storekey) && store.get(storekey).size),
+        (folderSettings && folderSettings.size),
+        settings.sizes[0]
+    ],
+    settings.sizes
+);
 
 const updateView = () => {
     const mode = getMode();
@@ -126,8 +137,6 @@ const set = (mode, size) => {
 
     mode = mode || stored && stored.mode;
     size = size || stored && stored.size;
-    mode = includes(settings.modes, mode) ? mode : settings.modes[0];
-    size = includes(settings.sizes, size) ? size : settings.sizes[0];
 
     // Unset if it's being set back to the default value
     if (mode === settings.modes[0]) {


### PR DESCRIPTION
This adds the ability to customize options on a per-directory basis. My main use case is to use the "icons" view as the default view just for certain directories (directories containing pictures), while using the "details" view for everything else.

This needed some changes:
 - In addition to the per-directory header and footer files (eg. `_h5ai.header.html`), also look for a JSON file called `_h5ai.options.json`. It will look from the current directory all the way up to the root directory, merging all the configs together (child directories inherit the config from their ancestors, and can override individual fields)
 - Don't persist mode and size to local storage. Currently, h5ai immediately writes the default mode to local storage as soon as you load it. However, this means that we can't tell if the user has customized the view, or if they're just using the default settings. It also means that changing the default view won't be reflected on page load (as the old default will be persisted to local storage) I want to use the per-directory defaults if the user has not customized the setting, but use their custom setting if they **have** changed it. I'm instead only writing to local storage if the user changes the selection, and the **read** path is what selects the default if needed

Closes #668