### PR TITLE
Allow for setting control schemes based on the preview type

### DIFF
--- a/src/_h5ai/public/js/lib/ext/preview/preview-vid.js
+++ b/src/_h5ai/public/js/lib/ext/preview/preview-vid.js
@@ -2,6 +2,8 @@ const {dom} = require('../../util');
 const allsettings = require('../../core/settings');
 const preview = require('./preview');
 
+preview.setControlType("vid")
+
 const settings = Object.assign({
     enabled: false,
     autoplay: true,

--- a/src/_h5ai/public/js/lib/ext/preview/preview.js
+++ b/src/_h5ai/public/js/lib/ext/preview/preview.js
@@ -131,7 +131,25 @@ const dropEvent = ev => {
     ev.preventDefault();
 };
 
-const onKeydown = ev => {
+// const onKeydown = ev => {
+//     const key = ev.keyCode;
+
+//     if (key === 27) { // esc
+//         dropEvent(ev);
+//         exit(); // eslint-disable-line no-use-before-define
+//     } else if (key === 8 || key === 37) { // backspace, left
+//         dropEvent(ev);
+//         prev();
+//     } else if (key === 13 || key === 32 || key === 39) { // enter, space, right
+//         dropEvent(ev);
+//         next();
+//     } else if (key === 70) { // f
+//         dropEvent(ev);
+//         toggleFullscreen();
+//     }
+// };
+
+const defaultControls = ev => {
     const key = ev.keyCode;
 
     if (key === 27) { // esc
@@ -147,7 +165,42 @@ const onKeydown = ev => {
         dropEvent(ev);
         toggleFullscreen();
     }
-};
+}
+
+const videoControls = ev => {
+    const key = ev.keyCode;
+
+    if (key === 27) { // esc
+        dropEvent(ev);
+        exit(); // eslint-disable-line no-use-before-define
+    } else if (key === 8 || key === 188) { // backspace === 8; , ===188
+        dropEvent(ev);
+        prev();
+    } else if (key === 13 || key === 190) { // enter === 13; . ===190
+        dropEvent(ev);
+        next();
+    } else if (key === 70) { // f
+        dropEvent(ev);
+        toggleFullscreen();
+    }
+}
+
+const onKeydown = ev => {
+    
+    switch(Preview.controlsType){
+        case "vid":
+            videoControls(ev)
+            break;
+        default:
+            defaultControls(ev)
+    }
+}
+
+const setControlType = (t) =>{
+    Preview.controlsType = t
+}
+
+
 
 const enter = () => {
     setLabels([]);
@@ -284,12 +337,15 @@ const init = () => {
         .on('load', updateGui);
 };
 
-module.exports = {
+
+var Preview =  module.exports = {
     setLabels,
     register,
     get item() {
         return session && session.item;
-    }
+    },
+    controlsType:"default",
+    setControlType
 };
 
 init();


### PR DESCRIPTION
Fixes #700 

Preview exports a "setControllerType" function that just sets its "controlsType" to a string.

The onKeydown event is changed to a switch case that defaults to the default controls as they are now.  But if the controlsType matches a switch it will pass the event to a different function which can set the controls slightly differently.

In this case we stop listening for the space key and left and right arrows for "vid"eos.  This lets the video playback pan left and right with the arrow keys and pause and start with spacebar, as most default video players work.



This makes adding new control schemes easy for each preview-TYPE.js.

I do think adding a "?" somewhere on the preview screen that allows for a snippet about what the controls for this preview are would be helpful... For example it's unlikely users would find out that "." and "," can be used in the video preview to skip to the next and previous video.

It should also be configurable by the main config.json to allow turning on and off the controls ( even setting them?? ) because technically now a dir with images and videos will change controls depending on the media shown.

Lastly maybe the best approach would have just been to change the default controls to slightly less common keys!