### PR TITLE
Close the session for writing when sending a file

### DIFF
--- a/src/_h5ai/private/php/core/class-api.php
+++ b/src/_h5ai/private/php/core/class-api.php
@@ -31,6 +31,7 @@ class Api {
         $archive = new Archive($this->context);
 
         set_time_limit(0);
+        session_write_close();
         header('Content-Type: application/octet-stream');
         header('Content-Disposition: attachment; filename="' . $as . '"');
         header('Connection: close');


### PR DESCRIPTION
Right now, if you download an archive, you won't be able to browse within h5ai until the download is finished. This is because the session data is locked to prevent concurrent writes, which also prevents concurrent requests.

By adding `session_write_close()` in the `on_download` function, the session lock is released and concurrent requests will work.