### PR TITLE
Add EXIF based image rotate for firefox

### DIFF
--- a/src/_h5ai/public/css/lib/ext/preview-img.less
+++ b/src/_h5ai/public/css/lib/ext/preview-img.less
@@ -6,6 +6,8 @@
 
     position: absolute;
 
+    image-orientation: from-image;
+    
     max-width: 100%;
     max-height: 100%;
 


### PR DESCRIPTION
Chrome 81 / Safari 13.1 does this automatically. Firefox still requires this CSS. According to spec (css4) it is now deprecated but implementation is optional.