### PR TITLE
Fix #760

### DIFF
--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -3,6 +3,12 @@
 class Context {
     private static $DEFAULT_PASSHASH = 'cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e';
     private static $AS_ADMIN_SESSION_KEY = 'AS_ADMIN';
+    private static $L10N_ISO_CODES = array(
+        'af', 'bg', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fi', 'fr', 'he',
+        'hi', 'hr', 'hu', 'id', 'it', 'ja','ko', 'lv', 'nb', 'nl', 'pl',
+        'pt-br', 'pt-pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'tr', 'uk',
+        'zh-cn', 'zh-tw',
+    );
 
     private $session;
     private $request;
@@ -227,6 +233,10 @@ class Context {
         $results = [];
 
         foreach ($iso_codes as $iso_code) {
+            if (!in_array($iso_code, $this->$L10N_ISO_CODES)) {
+                continue;
+            }
+
             $file = $this->setup->get('CONF_PATH') . '/l10n/' . $iso_code . '.json';
             $results[$iso_code] = Json::load($file);
             $results[$iso_code]['isoCode'] = $iso_code;

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -233,7 +233,7 @@ class Context {
         $results = [];
 
         foreach ($iso_codes as $iso_code) {
-            if (!in_array($iso_code, $this->$L10N_ISO_CODES)) {
+            if (!in_array($iso_code, Context::$L10N_ISO_CODES)) {
                 continue;
             }
 


### PR DESCRIPTION
Fix #760.

Limit l10n iso code available values.

Available l10n codes are collected from `conf/l10n` dir.
