### PR TITLE
Fix short videos thumbnail generation

### DIFF
--- a/src/_h5ai/private/php/core/class-setup.php
+++ b/src/_h5ai/private/php/core/class-setup.php
@@ -130,7 +130,7 @@ class Setup {
                 $cmd = 'which';
             }
 
-            foreach (['avconv', 'convert', 'du', 'ffmpeg', 'gm', 'tar', 'zip'] as $c) {
+            foreach (['avconv', 'avprobe', 'convert', 'du', 'ffmpeg', 'ffprobe', 'gm', 'tar', 'zip'] as $c) {
                 $cmds[$c] = ($cmd !== false) && (Util::exec_0($cmd . ' ' . $c) || Util::exec_0($cmd . ' ' . $c . '.exe'));
             }
 

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -59,16 +59,24 @@ class Util {
         return $rc;
     }
 
-    public static function exec_cmdv($cmdv) {
+    public static function exec_cmdv($cmdv, $capture = false, $redirect = false) {
         if (!is_array($cmdv)) {
             $cmdv = func_get_args();
         }
         $cmd = implode(' ', array_map('escapeshellarg', $cmdv));
 
-        $lines = [];
-        $rc = null;
-        exec($cmd, $lines, $rc);
-        return implode("\n", $lines);
+        if ($redirect) {
+            // Redirect stderr to stdout (notably for ffmpeg)
+            $cmd .= ' 2>&1'; // This cannot be shellarg-escaped
+        }
+
+        if ($capture){
+            $lines = [];
+            $rc = null;
+            exec($cmd, $lines, $rc);
+            return [implode("\n", $lines), $rc];
+        }
+        exec($cmd);
     }
 
     public static function exec_0($cmd) {

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -29,7 +29,6 @@ class Thumb {
             return null;
         }
 
-        $capture_path = $source_path;
         if ($type === 'img') {
             $capture_path = $source_path;
         } elseif ($type === 'mov') {
@@ -44,6 +43,8 @@ class Thumb {
             } elseif ($this->setup->get('HAS_CMD_GM')) {
                 $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path);
             }
+        } else {
+            $capture_path = $source_path;
         }
 
         return $this->thumb_href($capture_path, $width, $height);

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -1,10 +1,12 @@
 <?php
 
 class Thumb {
-    private static $FFMPEG_CMDV = ['ffmpeg', '-ss', '0:00:10', '-i', '[SRC]', '-an', '-vframes', '1', '[DEST]'];
-    private static $AVCONV_CMDV = ['avconv', '-ss', '0:00:10', '-i', '[SRC]', '-an', '-vframes', '1', '[DEST]'];
-    private static $CONVERT_CMDV = ['convert', '-density', '200', '-quality', '100', '-strip', '[SRC][0]', '[DEST]'];
-    private static $GM_CONVERT_CMDV = ['gm', 'convert', '-density', '200', '-quality', '100', '[SRC][0]', '[DEST]'];
+    private static $FFMPEG_CMDV = ['ffmpeg', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $FFPROBE_CMDV = ['ffprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
+    private static $AVCONV_CMDV = ['avconv', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $AVPROBE_CMDV = ['avprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
+    private static $CONVERT_CMDV = ['convert', '-density', '200', '-quality', '100', '-strip', '[H5AI_SRC][0]', '[H5AI_DEST]'];
+    private static $GM_CONVERT_CMDV = ['gm', 'convert', '-density', '200', '-quality', '100', '[H5AI_SRC][0]', '[H5AI_DEST]'];
     private static $THUMB_CACHE = 'thumbs';
 
     private $context;
@@ -33,15 +35,15 @@ class Thumb {
             $capture_path = $source_path;
         } elseif ($type === 'mov') {
             if ($this->setup->get('HAS_CMD_AVCONV')) {
-                $capture_path = $this->capture(Thumb::$AVCONV_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$AVCONV_CMDV, $source_path, $type);
             } elseif ($this->setup->get('HAS_CMD_FFMPEG')) {
-                $capture_path = $this->capture(Thumb::$FFMPEG_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$FFMPEG_CMDV, $source_path, $type);
             }
         } elseif ($type === 'doc') {
             if ($this->setup->get('HAS_CMD_CONVERT')) {
-                $capture_path = $this->capture(Thumb::$CONVERT_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$CONVERT_CMDV, $source_path, $type);
             } elseif ($this->setup->get('HAS_CMD_GM')) {
-                $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path, $type);
             }
         } else {
             $capture_path = $source_path;
@@ -81,7 +83,7 @@ class Thumb {
         return file_exists($thumb_path) ? $thumb_href : null;
     }
 
-    private function capture($cmdv, $source_path) {
+    private function capture($cmdv, $source_path, $type) {
         if (!file_exists($source_path)) {
             return null;
         }
@@ -89,15 +91,48 @@ class Thumb {
         $capture_path = $this->thumbs_path . '/capture-' . sha1($source_path) . '.jpg';
 
         if (!file_exists($capture_path) || filemtime($source_path) >= filemtime($capture_path)) {
-            foreach ($cmdv as &$arg) {
-                $arg = str_replace('[SRC]', $source_path, $arg);
-                $arg = str_replace('[DEST]', $capture_path, $arg);
+            $movtype = ($type === 'mov') ? true : false;
+            if ($movtype) {
+                try {
+                    if ($cmdv[0] === 'ffmpeg') {
+                        $timestamp = $this->compute_duration(Thumb::$FFPROBE_CMDV, $source_path);
+                    } else {
+                        $timestamp = $this->compute_duration(Thumb::$AVPROBE_CMDV, $source_path);
+                    }
+                } catch(Exception $e) {
+                    // Attempt to capture after the first second anyway
+                    $timestamp = "1";
+                }
+                foreach ($cmdv as &$arg) {
+                    $arg = str_replace(
+                        ['[H5AI_SRC]', '[H5AI_DEST]', '[DUR]'],
+                        [$source_path, $capture_path, $timestamp],
+                        $arg
+                    );
+                }
             }
-
+            else {
+                foreach ($cmdv as &$arg) {
+                    $arg = str_replace(['[H5AI_SRC]', '[H5AI_DEST]'], [$source_path, $capture_path], $arg);
+                }
+            }
             Util::exec_cmdv($cmdv);
         }
 
         return file_exists($capture_path) ? $capture_path : null;
+    }
+
+    private function compute_duration($cmdv, $source_path) {
+        foreach ($cmdv as &$arg) {
+            $arg = str_replace('[H5AI_SRC]', $source_path, $arg);
+        }
+        $result = Util::exec_cmdv($cmdv);
+        if (empty($result)) {
+            throw new Exception("Incorrect video duration returned: \"".$result."\"");
+        }
+        // Seek at 15% of the total video duration
+        $ret = strval(round(((floatval($result) * 15) / 100), 1, PHP_ROUND_HALF_UP));
+        return $ret;
     }
 }
 


### PR DESCRIPTION
* Use ffprobe/avprobe to get the total duration of each video file first.
* Compute a desired optimal timestamp of 15% of the total duration to seek for and get the thumbnail from.
* Fix capture of ffmpeg's output (from stderr) in exec_cmdv() by using an optional redirection to stdout.
* Capture of sub-process output is optional (possible slight performance gain).

This fixes #763, and possibly #754 also.