### PR TITLE
Fix thumbnail generation for mis-detected file types

### DIFF
--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -255,7 +255,7 @@ class Context {
     }
 
     public function write_log($msg){
-        Util::write_log($msg, $this->setup->get('CACHE_PRV_PATH'));
+        Util::write_log($msg, $this->setup->get('PRIVATE_PATH'));
     }
 
     private function prefix_x_head_href($href) {

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -245,18 +245,12 @@ class Context {
             }
             else if ($thumbs[$href]->type === 'file') {
                 // File has already been mime tested and cannot have a thumbnail
-                // $this->write_log($href." FLAGGED as FILE. Skipping.");
                 $hrefs[] = null;
                 continue;
             }
             $hrefs[] = $thumbs[$href]->thumb($req['width'], $req['height']);
         }
-
         return $hrefs;
-    }
-
-    public function write_log($msg){
-        Util::write_log($msg, $this->setup->get('PRIVATE_PATH'));
     }
 
     private function prefix_x_head_href($href) {

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -245,6 +245,7 @@ class Context {
             }
             else if ($thumbs[$href]->type === 'file') {
                 // File has already been mime tested and cannot have a thumbnail
+                // $this->write_log($href." FLAGGED as FILE. Skipping.");
                 $hrefs[] = null;
                 continue;
             }

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -237,13 +237,25 @@ class Context {
 
     public function get_thumbs($requests) {
         $hrefs = [];
-
+        $thumbs = [];
         foreach ($requests as $req) {
-            $thumb = new Thumb($this);
-            $hrefs[] = $thumb->thumb($req['type'], $req['href'], $req['width'], $req['height']);
+            $href = $this->to_path($req['href']);
+            if (!array_key_exists($href, $thumbs)) {
+                $thumbs[$href] = new Thumb($this, $href, $req['type']);
+            }
+            else if ($thumbs[$href]->type === 'file') {
+                // File has already been mime tested and cannot have a thumbnail
+                $hrefs[] = null;
+                continue;
+            }
+            $hrefs[] = $thumbs[$href]->thumb($req['width'], $req['height']);
         }
 
         return $hrefs;
+    }
+
+    public function write_log($msg){
+        Util::write_log($msg, $this->setup->get('CACHE_PRV_PATH'));
     }
 
     private function prefix_x_head_href($href) {

--- a/src/_h5ai/private/php/core/class-setup.php
+++ b/src/_h5ai/private/php/core/class-setup.php
@@ -67,11 +67,7 @@ class Setup {
         }
         $this->set('HAS_PHP_JPEG', $has_php_jpeg);
 
-        $has_fileinfo = false;
-        if (extension_loaded('fileinfo')){
-            $has_fileinfo = true;
-        }
-        $this->set('HAS_PHP_FILEINFO', $has_fileinfo);
+        $this->set('HAS_PHP_FILEINFO', extension_loaded('fileinfo'));
     }
 
     private function add_app_metadata() {

--- a/src/_h5ai/private/php/core/class-setup.php
+++ b/src/_h5ai/private/php/core/class-setup.php
@@ -66,6 +66,12 @@ class Setup {
             $has_php_jpeg = array_key_exists('JPEG Support', $infos) && $infos['JPEG Support'];
         }
         $this->set('HAS_PHP_JPEG', $has_php_jpeg);
+
+        $has_fileinfo = false;
+        if (extension_loaded('fileinfo')){
+            $has_fileinfo = true;
+        }
+        $this->set('HAS_PHP_FILEINFO', $has_fileinfo);
     }
 
     private function add_app_metadata() {
@@ -156,6 +162,7 @@ class Setup {
                 'PHP_ARCH',
                 'HAS_PHP_EXIF',
                 'HAS_PHP_JPEG',
+                'HAS_PHP_FILEINFO',
 
                 'SERVER_NAME',
                 'SERVER_VERSION',

--- a/src/_h5ai/private/php/core/class-setup.php
+++ b/src/_h5ai/private/php/core/class-setup.php
@@ -130,7 +130,7 @@ class Setup {
                 $cmd = 'which';
             }
 
-            foreach (['avconv', 'convert', 'du', 'ffmpeg', 'gm', 'tar', 'zip'] as $c) {
+            foreach (['avconv', 'avprobe', 'convert', 'du', 'ffmpeg', 'ffprobe', 'gm', 'tar', 'zip'] as $c) {
                 $cmds[$c] = ($cmd !== false) && (Util::exec_0($cmd . ' ' . $c) || Util::exec_0($cmd . ' ' . $c . '.exe'));
             }
 

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -76,7 +76,7 @@ class Util {
             exec($cmd, $lines, $rc);
             return [implode("\n", $lines), $rc];
         }
-        exec($cmd);
+        return exec($cmd);
     }
 
     public static function exec_0($cmd) {

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -71,7 +71,7 @@ class Util {
             $lines = [];
             $rc = null;
             exec($cmd, $lines, $rc);
-            return [implode("\n", $lines), $rc];
+            return [$lines, $rc];
         }
         return exec($cmd);
     }
@@ -90,5 +90,34 @@ class Util {
         $withFoldersize = $context->query_option('foldersize.enabled', false);
         $withDu = $context->get_setup()->get('HAS_CMD_DU') && $context->query_option('foldersize.type', null) === 'shell-du';
         return Filesize::getCachedSize($path, $withFoldersize, $withDu);
+    }
+
+    public static function get_mimetype($source_path) {
+        //return mime_content_type($filename);
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        return $finfo->file($source_path);
+    }
+
+    public static function mime_to_type($mime) {
+        if (strpos($mime, 'image') !== false) {
+            return 'img';
+        }
+        if (strpos($mime, 'video') !== false) {
+            return 'mov';
+        }
+        if (strpos($mime, 'pdf') !== false) {
+            return 'doc';
+        }
+        return false;
+    }
+
+    public static function write_log($log_msg, $log_filename) {
+        if (!file_exists($log_filename))
+        {
+            mkdir($log_filename, 0777, true);
+        }
+        $log_file_data = $log_filename.'/debug.log';
+        $log_msg = date('Y-m-d H:i:s')." ".$log_msg;
+        file_put_contents($log_file_data, $log_msg . "\n", FILE_APPEND);
     }
 }

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -87,6 +87,8 @@ class Util {
     }
 
     public static function proc_open_cmdv($cmdv, &$output, &$error) {
+        /* If output is of type [resource] a file handle to the output will be
+            written to it. Otherwise, output will receive the output as a string */
         $cmd = implode(' ', array_map('escapeshellarg', $cmdv));
 
         $descriptorspec = array(
@@ -100,7 +102,11 @@ class Util {
             /*fwrite($pipes[0], '');*/
             fclose($pipes[0]);
 
-            $output = stream_get_contents($pipes[1]);
+            if (is_resource($output)) {
+                fwrite($output, stream_get_contents($pipes[1]));
+            } else {
+                $output = stream_get_contents($pipes[1]);
+            }
             fclose($pipes[1]);
 
             $error = stream_get_contents($pipes[2]);
@@ -140,7 +146,7 @@ class Util {
         return 'file';
     }
 
-    public static function write_log($log_msg, $log_filename) {
+    public static function write_log($log_msg, $log_filename = '/ssd_data/shared/_h5ai/private') {
         if (!file_exists($log_filename))
         {
             mkdir($log_filename, 0777, true);

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -60,9 +60,6 @@ class Util {
     }
 
     public static function exec_cmdv($cmdv, $capture = false, $redirect = false) {
-        if (!is_array($cmdv)) {
-            $cmdv = func_get_args();
-        }
         $cmd = implode(' ', array_map('escapeshellarg', $cmdv));
 
         if ($redirect) {

--- a/src/_h5ai/private/php/core/class-util.php
+++ b/src/_h5ai/private/php/core/class-util.php
@@ -59,16 +59,24 @@ class Util {
         return $rc;
     }
 
-    public static function exec_cmdv($cmdv) {
+    public static function exec_cmdv($cmdv, $capture = false, $redirect = false) {
         if (!is_array($cmdv)) {
             $cmdv = func_get_args();
         }
         $cmd = implode(' ', array_map('escapeshellarg', $cmdv));
 
-        $lines = [];
-        $rc = null;
-        exec($cmd, $lines, $rc);
-        return implode("\n", $lines);
+        if ($redirect) {
+            // Redirect stderr to stdout (notably for ffmpeg)
+            $cmd .= ' 2>&1'; // This cannot be shellarg-escaped
+        }
+
+        if ($capture){
+            $lines = [];
+            $rc = null;
+            exec($cmd, $lines, $rc);
+            return [implode("\n", $lines), $rc];
+        }
+        exec($cmd);
     }
 
     public static function exec_0($cmd) {

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -1,9 +1,9 @@
 <?php
 
 class Thumb {
-    private static $FFMPEG_CMDV = ['ffmpeg', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $FFMPEG_CMDV = ['ffmpeg', '-nostdin', '-y', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
     private static $FFPROBE_CMDV = ['ffprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
-    private static $AVCONV_CMDV = ['avconv', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $AVCONV_CMDV = ['avconv', '-nostdin', '-y', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
     private static $AVPROBE_CMDV = ['avprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
     private static $CONVERT_CMDV = ['convert', '-density', '200', '-quality', '100', '-strip', '[H5AI_SRC][0]', '[H5AI_DEST]'];
     private static $GM_CONVERT_CMDV = ['gm', 'convert', '-density', '200', '-quality', '100', '[H5AI_SRC][0]', '[H5AI_DEST]'];

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -29,7 +29,6 @@ class Thumb {
             return null;
         }
 
-        $capture_path = $source_path;
         if ($type === 'img') {
             $capture_path = $source_path;
         } elseif ($type === 'mov') {
@@ -44,6 +43,8 @@ class Thumb {
             } elseif ($this->setup->get('HAS_CMD_GM')) {
                 $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path);
             }
+        } else {
+            $capture_path = $source_path;
         }
 
         return $this->thumb_href($capture_path, $width, $height);

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -1,10 +1,12 @@
 <?php
 
 class Thumb {
-    private static $FFMPEG_CMDV = ['ffmpeg', '-ss', '0:00:10', '-i', '[SRC]', '-an', '-vframes', '1', '[DEST]'];
-    private static $AVCONV_CMDV = ['avconv', '-ss', '0:00:10', '-i', '[SRC]', '-an', '-vframes', '1', '[DEST]'];
-    private static $CONVERT_CMDV = ['convert', '-density', '200', '-quality', '100', '-strip', '[SRC][0]', '[DEST]'];
-    private static $GM_CONVERT_CMDV = ['gm', 'convert', '-density', '200', '-quality', '100', '[SRC][0]', '[DEST]'];
+    private static $FFMPEG_CMDV = ['ffmpeg', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $FFPROBE_CMDV = ['ffprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
+    private static $AVCONV_CMDV = ['avconv', '-nostdin', '-hide_banner', '-ss', '[DUR]', '-i', '[H5AI_SRC]', '-an', '-vframes', '1', '[H5AI_DEST]'];
+    private static $AVPROBE_CMDV = ['avprobe', '-v', 'quiet', '-show_format_entry', 'duration', '-of', 'default=noprint_wrappers=1:nokey=1', '[H5AI_SRC]'];
+    private static $CONVERT_CMDV = ['convert', '-density', '200', '-quality', '100', '-strip', '[H5AI_SRC][0]', '[H5AI_DEST]'];
+    private static $GM_CONVERT_CMDV = ['gm', 'convert', '-density', '200', '-quality', '100', '[H5AI_SRC][0]', '[H5AI_DEST]'];
     private static $THUMB_CACHE = 'thumbs';
 
     private $context;
@@ -33,15 +35,15 @@ class Thumb {
             $capture_path = $source_path;
         } elseif ($type === 'mov') {
             if ($this->setup->get('HAS_CMD_AVCONV')) {
-                $capture_path = $this->capture(Thumb::$AVCONV_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$AVCONV_CMDV, $source_path, $type);
             } elseif ($this->setup->get('HAS_CMD_FFMPEG')) {
-                $capture_path = $this->capture(Thumb::$FFMPEG_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$FFMPEG_CMDV, $source_path, $type);
             }
         } elseif ($type === 'doc') {
             if ($this->setup->get('HAS_CMD_CONVERT')) {
-                $capture_path = $this->capture(Thumb::$CONVERT_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$CONVERT_CMDV, $source_path, $type);
             } elseif ($this->setup->get('HAS_CMD_GM')) {
-                $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path);
+                $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path, $type);
             }
         } else {
             $capture_path = $source_path;
@@ -81,7 +83,7 @@ class Thumb {
         return file_exists($thumb_path) ? $thumb_href : null;
     }
 
-    private function capture($cmdv, $source_path) {
+    private function capture($cmdv, $source_path, $type) {
         if (!file_exists($source_path)) {
             return null;
         }
@@ -89,15 +91,48 @@ class Thumb {
         $capture_path = $this->thumbs_path . '/capture-' . sha1($source_path) . '.jpg';
 
         if (!file_exists($capture_path) || filemtime($source_path) >= filemtime($capture_path)) {
-            foreach ($cmdv as &$arg) {
-                $arg = str_replace('[SRC]', $source_path, $arg);
-                $arg = str_replace('[DEST]', $capture_path, $arg);
+            $movtype = ($type === 'mov') ? true : false;
+            if ($movtype) {
+                try {
+                    if ($cmdv[0] === 'ffmpeg') {
+                        $timestamp = $this->compute_duration(Thumb::$FFPROBE_CMDV, $source_path);
+                    } else {
+                        $timestamp = $this->compute_duration(Thumb::$AVPROBE_CMDV, $source_path);
+                    }
+                } catch(Exception $e) {
+                    // Attempt to capture after the first second anyway
+                    $timestamp = "1";
+                }
+                foreach ($cmdv as &$arg) {
+                    $arg = str_replace(
+                        ['[H5AI_SRC]', '[H5AI_DEST]', '[DUR]'],
+                        [$source_path, $capture_path, $timestamp],
+                        $arg
+                    );
+                }
             }
-
+            else {
+                foreach ($cmdv as &$arg) {
+                    $arg = str_replace(['[H5AI_SRC]', '[H5AI_DEST]'], [$source_path, $capture_path], $arg);
+                }
+            }
             Util::exec_cmdv($cmdv);
         }
 
         return file_exists($capture_path) ? $capture_path : null;
+    }
+
+    private function compute_duration($cmdv, $source_path) {
+        foreach ($cmdv as &$arg) {
+            $arg = str_replace('[H5AI_SRC]', $source_path, $arg);
+        }
+        $result = Util::exec_cmdv($cmdv);
+        if (empty($result)) {
+            throw new Exception("Incorrect video duration returned: \"".$result."\"");
+        }
+        // Seek at 15% of the total video duration
+        $ret = strval(round(((floatval($result) * 15) / 100), 1, PHP_ROUND_HALF_UP));
+        return $ret;
     }
 }
 

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -43,7 +43,7 @@ class Thumb {
         }
 
         $size = count($types);
-        $this->context->write_log("Types".$size." for ".$source_path." of type ".$type." : ".print_r($types, true));
+        // $this->context->write_log("Types".$size." for ".$source_path." of type ".$type." : ".print_r($types, true));
         $thumb = null;
         $attempt = 0;
         do {
@@ -61,7 +61,7 @@ class Thumb {
                 } elseif ($this->setup->get('HAS_CMD_GM')) {
                     $capture_path = $this->capture(Thumb::$GM_CONVERT_CMDV, $source_path, $type);
                 }
-            } else {
+            } elseif ($this->setup->get('HAS_PHP_FILEINFO')) {
                 $mimetype = Util::get_mimetype($source_path);
                 $detected_type = Util::mime_to_type($mimetype);
                 $this->context->write_log("\nSource: ".$source_path."\ntype: ".$type."\nmimetype: ".$mimetype."\ndetected: ".$detected_type."\nattempt: ".$attempt."\n");
@@ -70,6 +70,8 @@ class Thumb {
                     continue;
                 }
                 break;
+            } else {
+                return null;
             }
             $thumb = $this->thumb_href($capture_path, $width, $height);
             if (!is_null($thumb)){
@@ -117,7 +119,7 @@ class Thumb {
         return file_exists($thumb_path) ? $thumb_href : null;
     }
 
-    private function capture($cmdv, $source_path, $type) {
+    private function capture($cmdv, $source_path, $type, $in_memory = true) {
         if (!file_exists($source_path)) {
             return null;
         }

--- a/src/_h5ai/public/js/lib/ext/thumbnails.js
+++ b/src/_h5ai/public/js/lib/ext/thumbnails.js
@@ -20,13 +20,19 @@ const queueItem = (queue, item) => {
     let type = null;
 
     if (includes(settings.img, item.type)) {
+        console.log("DEBUG: item.type [img] is", item.type, item);
         type = 'img';
     } else if (includes(settings.mov, item.type)) {
+        console.log("DEBUG: item.type [mov] is", item.type, item);
         type = 'mov';
     } else if (includes(settings.doc, item.type)) {
+        console.log("DEBUG: item.type [doc] is", item.type, item);
         type = 'doc';
-    } else {
+    } else if (item.type === 'folder') {
         return;
+    } else {
+        console.log("DEBUG: item.type is", item.type, item);
+        type = 'file'
     }
 
     if (item.thumbSquare) {

--- a/src/_h5ai/public/js/lib/ext/thumbnails.js
+++ b/src/_h5ai/public/js/lib/ext/thumbnails.js
@@ -20,18 +20,14 @@ const queueItem = (queue, item) => {
     let type = null;
 
     if (includes(settings.img, item.type)) {
-        console.log("DEBUG: item.type [img] is", item.type, item);
         type = 'img';
     } else if (includes(settings.mov, item.type)) {
-        console.log("DEBUG: item.type [mov] is", item.type, item);
         type = 'mov';
     } else if (includes(settings.doc, item.type)) {
-        console.log("DEBUG: item.type [doc] is", item.type, item);
         type = 'doc';
     } else if (item.type === 'folder') {
         return;
     } else {
-        console.log("DEBUG: item.type is", item.type, item);
         type = 'file'
     }
 

--- a/src/_h5ai/public/js/lib/main/info.js
+++ b/src/_h5ai/public/js/lib/main/info.js
@@ -103,6 +103,11 @@ const addTests = () => {
     );
 
     addTest(
+        'Fileinfo module', 'PHP Fileinfo extension is available',
+        setup.HAS_PHP_FILEINFO
+    );
+
+    addTest(
         'Use EXIF thumbs', 'PHP EXIF extension available',
         setup.HAS_PHP_EXIF
     );


### PR DESCRIPTION
* If a file failed to be detected via filename extension by the javascript frontend, try to detect its type to generate a thumbnail.
* Use mime type detection to determine the actual file type (if FileInfo module is indeed loaded).
* Don't write capture file to hard drive disk anymore, but keep it in memory until final thumbnails have been generated.
* Fix SWF file not being having thumbnails generated when they could.
* Various performance improvements by reducing superfluous or redundant checks.