### PR TITLE
Fix DoS thumbnail generation exploit

### DIFF
--- a/src/_h5ai/private/conf/options.json
+++ b/src/_h5ai/private/conf/options.json
@@ -234,11 +234,9 @@
     Show an image preview on click.
 
     - types: array of strings
-    - size: number, sample size, or false for original size
     */
     "preview-img": {
         "enabled": true,
-        "size": false,
         "types": ["img", "img-bmp", "img-gif", "img-ico", "img-jpg", "img-png", "img-raw", "img-svg"]
     },
 

--- a/src/_h5ai/private/conf/options.json
+++ b/src/_h5ai/private/conf/options.json
@@ -355,7 +355,7 @@
     - mov: array of strings
     - doc: array of strings
     - delay: number, delay in milliseconds after "dom-ready" before thumb-requesting starts
-    - size: number, size in pixel of the generated thumbnails
+    - size: number, height in pixel of the generated thumbnails
     - exif: boolean, use included EXIF thumbs if possible
     - chunksize: int, number of thumbs per request
     */

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -248,7 +248,7 @@ class Context {
     public function get_thumbs($requests) {
         $hrefs = [];
         $height = $this->options['thumbnails']['size'] ?? 240;
-        $width = floor($this->thumbnail_height * (4 / 3));
+        $width = floor($height * (4 / 3));
 
         foreach ($requests as $req) {
             $thumb = new Thumb($this);

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -23,6 +23,9 @@ class Context {
 
         $this->options = Json::load($this->setup->get('CONF_PATH') . '/options.json');
 
+        $this->thumbnail_height = $this->options['thumbnails']['size'] ?? 240;
+        $this->thumbnail_width = floor($this->thumbnail_height * (4 / 3));
+
         $this->passhash = $this->query_option('passhash', '');
         $this->options['hasCustomPasshash'] = strcasecmp($this->passhash, Context::$DEFAULT_PASSHASH) !== 0;
         unset($this->options['passhash']);
@@ -250,7 +253,7 @@ class Context {
 
         foreach ($requests as $req) {
             $thumb = new Thumb($this);
-            $hrefs[] = $thumb->thumb($req['type'], $req['href'], $req['width'], $req['height']);
+            $hrefs[] = $thumb->thumb($req['type'], $req['href']);
         }
 
         return $hrefs;

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -23,9 +23,6 @@ class Context {
 
         $this->options = Json::load($this->setup->get('CONF_PATH') . '/options.json');
 
-        $this->thumbnail_height = $this->options['thumbnails']['size'] ?? 240;
-        $this->thumbnail_width = floor($this->thumbnail_height * (4 / 3));
-
         $this->passhash = $this->query_option('passhash', '');
         $this->options['hasCustomPasshash'] = strcasecmp($this->passhash, Context::$DEFAULT_PASSHASH) !== 0;
         unset($this->options['passhash']);
@@ -250,10 +247,12 @@ class Context {
 
     public function get_thumbs($requests) {
         $hrefs = [];
+        $height = $this->options['thumbnails']['size'] ?? 240;
+        $width = floor($this->thumbnail_height * (4 / 3));
 
         foreach ($requests as $req) {
             $thumb = new Thumb($this);
-            $hrefs[] = $thumb->thumb($req['type'], $req['href']);
+            $hrefs[] = $thumb->thumb($req['type'], $req['href'], $width, $height);
         }
 
         return $hrefs;

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -23,7 +23,7 @@ class Thumb {
         }
     }
 
-    public function thumb($type, $source_href) {
+    public function thumb($type, $source_href, $width, $height) {
         $source_path = $this->context->to_path($source_href);
         if (!file_exists($source_path) || Util::starts_with($source_path, $this->setup->get('CACHE_PUB_PATH'))) {
             return null;
@@ -46,7 +46,7 @@ class Thumb {
             }
         }
 
-        return $this->thumb_href($capture_path, $this->context->thumbnail_width, $this->context->thumbnail_height);
+        return $this->thumb_href($capture_path, $width, $height);
     }
 
     private function thumb_href($source_path, $width, $height) {

--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -23,7 +23,7 @@ class Thumb {
         }
     }
 
-    public function thumb($type, $source_href, $width, $height) {
+    public function thumb($type, $source_href) {
         $source_path = $this->context->to_path($source_href);
         if (!file_exists($source_path) || Util::starts_with($source_path, $this->setup->get('CACHE_PUB_PATH'))) {
             return null;
@@ -46,7 +46,7 @@ class Thumb {
             }
         }
 
-        return $this->thumb_href($capture_path, $width, $height);
+        return $this->thumb_href($capture_path, $this->context->thumbnail_width, $this->context->thumbnail_height);
     }
 
     private function thumb_href($source_path, $width, $height) {

--- a/src/_h5ai/public/css/lib/view/view.less
+++ b/src/_h5ai/public/css/lib/view/view.less
@@ -48,6 +48,8 @@
         .thumb {
             max-width: none;
             max-height: none;
+            object-fit: cover;
+            object-position: 50% 50%;
         }
     }
 

--- a/src/_h5ai/public/js/lib/ext/preview/preview-img.js
+++ b/src/_h5ai/public/js/lib/ext/preview/preview-img.js
@@ -1,11 +1,9 @@
 const {dom} = require('../../util');
-const server = require('../../server');
 const allsettings = require('../../core/settings');
 const preview = require('./preview');
 
 const settings = Object.assign({
     enabled: false,
-    size: null,
     types: []
 }, allsettings['preview-img']);
 const tpl = '<img id="pv-content-img"/>';
@@ -19,34 +17,16 @@ const updateGui = () => {
     const elW = el.offsetWidth;
 
     const labels = [preview.item.label];
-    if (!settings.size) {
-        const elNW = el.naturalWidth;
-        const elNH = el.naturalHeight;
-        labels.push(String(elNW) + 'x' + String(elNH));
-        labels.push(String((100 * elW / elNW).toFixed(0)) + '%');
-    }
-    preview.setLabels(labels);
-};
+    const elNW = el.naturalWidth;
+    const elNH = el.naturalHeight;
+    labels.push(String(elNW) + 'x' + String(elNH));
+    labels.push(String((100 * elW / elNW).toFixed(0)) + '%');
 
-const requestSample = href => {
-    return server.request({
-        action: 'get',
-        thumbs: [{
-            type: 'img',
-            href,
-            width: settings.size,
-            height: 0
-        }]
-    }).then(json => {
-        return json && json.thumbs && json.thumbs[0] ? json.thumbs[0] : null;
-    });
+    preview.setLabels(labels);
 };
 
 const load = item => {
     return Promise.resolve(item.absHref)
-        .then(href => {
-            return settings.size ? requestSample(href) : href;
-        })
         .then(href => new Promise(resolve => {
             const $el = dom(tpl)
                 .on('load', () => resolve($el))

--- a/src/_h5ai/public/js/lib/ext/preview/preview.js
+++ b/src/_h5ai/public/js/lib/ext/preview/preview.js
@@ -213,7 +213,7 @@ Session.prototype = {
                     }
                 });
                 dom('#pv-container').hide().clr();
-                showSpinner(true, item.thumbSquare || item.icon, 200);
+                showSpinner(true, item.thumbRational || item.icon, 200);
             })
             .then(() => this.load(item))
             // delay for testing

--- a/src/_h5ai/public/js/lib/ext/thumbnails.js
+++ b/src/_h5ai/public/js/lib/ext/thumbnails.js
@@ -13,7 +13,6 @@ const settings = Object.assign({
     exif: false,
     chunksize: 20
 }, allsettings.thumbnails);
-const landscapeRatio = 4 / 3;
 
 
 const queueItem = (queue, item) => {
@@ -35,7 +34,6 @@ const queueItem = (queue, item) => {
         queue.push({
             type,
             href: item.absHref,
-            ratio: 1,
             callback: src => {
                 if (src && item.$view) {
                     item.thumbSquare = src;
@@ -51,7 +49,6 @@ const queueItem = (queue, item) => {
         queue.push({
             type,
             href: item.absHref,
-            ratio: landscapeRatio,
             callback: src => {
                 if (src && item.$view) {
                     item.thumbRational = src;
@@ -67,8 +64,6 @@ const requestQueue = queue => {
         return {
             type: req.type,
             href: req.href,
-            width: Math.round(settings.size * req.ratio),
-            height: settings.size
         };
     });
 

--- a/src/_h5ai/public/js/lib/ext/thumbnails.js
+++ b/src/_h5ai/public/js/lib/ext/thumbnails.js
@@ -28,23 +28,8 @@ const queueItem = (queue, item) => {
         return;
     }
 
-    if (item.thumbSquare) {
-        item.$view.find('.icon.square img').addCls('thumb').attr('src', item.thumbSquare);
-    } else {
-        queue.push({
-            type,
-            href: item.absHref,
-            callback: src => {
-                if (src && item.$view) {
-                    item.thumbSquare = src;
-                    item.$view.find('.icon.square img').addCls('thumb').attr('src', src);
-                }
-            }
-        });
-    }
-
     if (item.thumbRational) {
-        item.$view.find('.icon.landscape img').addCls('thumb').attr('src', item.thumbRational);
+        item.$view.find('.icon img').addCls('thumb').attr('src', item.thumbRational);
     } else {
         queue.push({
             type,
@@ -52,7 +37,7 @@ const queueItem = (queue, item) => {
             callback: src => {
                 if (src && item.$view) {
                     item.thumbRational = src;
-                    item.$view.find('.icon.landscape img').addCls('thumb').attr('src', src);
+                    item.$view.find('.icon img').addCls('thumb').attr('src', src);
                 }
             }
         });


### PR DESCRIPTION
This fixes a denial-of-service exploit that would allow the client to generate an infinite number of thumbnails and fill up the hard disk storage completely very quickly.
Since the client had control over the requested thumbnail sizes, it could make arbitrary requests for thumbnails, with an arbitrary combination of width x height. Every time the back-end did not find an already generated thumbnail with the specified dimensions, it would happily generate a new one.

* Remove the ability of the client to decide thumbnail dimensions and only let the back-end do this by reading the configuration.
* Limit the number of generated thumbnails per file to only one, with "landscape" dimensions (4/3). This drastically reduces the amount of disk space used for thumbnails.
* A CSS "object-fit" property can be used to adjust displaying landscape thumbnails as squares when necessary. See https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit for more details. 