### PR TITLE
Custom title & meta info for shared links

### DIFF
--- a/src/_h5ai/private/conf/options.json
+++ b/src/_h5ai/private/conf/options.json
@@ -26,6 +26,17 @@
         ]
     },
 
+    /*
+    Custom Page Titles
+    - Placeholders available: DIR, PATH
+    - Link on "mydomain.com/foo/bar" with Pattern "MyShare DIR - PATH" generates "MyShare bar - foo/bar"
+    - If DIR is "" (doc root) fallback to "index"
+    (title has 65 and meta has 155 max. chars)
+    */
+    "pagetitle": {
+        "title": "DIR - powered by h5ai",
+        "desc": "shared files: PATH"
+    },
 
 
     /*

--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -289,6 +289,18 @@ class Context {
 
         $html = '';
 
+        $title = $this->query_option('pagetitle.title', "DIR index - powered by h5ai");
+        $meta  = $this->query_option('pagetitle.desc',  "shared files in PATH");
+
+        $path = trim($this->setup->get('REQUEST_HREF'), '/') ?: "index"; // fallback to index if root
+        $dir = substr(strrchr($path, '/'), 1) ?: $path; // fallback to dir = path if path contains no /
+
+        $title = str_replace('DIR', $dir, str_replace('PATH', $path, $title));
+        $meta  = str_replace('DIR', $dir, str_replace('PATH', $path, $meta ));
+
+        $html .= '<title>' . $title . '</title>';
+        $html .= '<meta name="description" content="' . $meta . '"/>';
+
         foreach ($styles as $href) {
             $html .= '<link rel="stylesheet" href="' . $this->prefix_x_head_href($href) . '" class="x-head">';
         }

--- a/src/_h5ai/private/php/pages/index.php.pug
+++ b/src/_h5ai/private/php/pages/index.php.pug
@@ -1,7 +1,6 @@
 extends ./page.tpl.pug
 
 block init
-    - var title = `index - powered by h5ai v${pkg.version} (${pkg.homepage})`
     - var module = 'index'
 
 block body

--- a/src/_h5ai/private/php/pages/info.php.pug
+++ b/src/_h5ai/private/php/pages/info.php.pug
@@ -1,7 +1,6 @@
 extends ./page.tpl.pug
 
 block init
-    - var title = `h5ai info page - v${pkg.version}`
     - var module = 'info'
 
 block body

--- a/src/_h5ai/private/php/pages/page.tpl.pug
+++ b/src/_h5ai/private/php/pages/page.tpl.pug
@@ -7,10 +7,9 @@ html(class='no-js', lang='en')
     head
         meta(charset='utf-8')
         meta(http-equiv='x-ua-compatible', content='ie=edge')
-        title #{title}
-        meta(name='description', content=title)
         meta(name='viewport', content='width=device-width, initial-scale=1')
         link(rel='shortcut icon', href!='<?= $public_href; ?>images/favicon/favicon-16-32.ico')
+        meta(property='og:image', content!='<?= $public_href; ?>images/favicon/favicon-152.png')
         link(rel='apple-touch-icon-precomposed', type='image/png', href!='<?= $public_href; ?>images/favicon/favicon-152.png')
         link(rel='stylesheet', href!='<?= $public_href; ?>css/styles.css')
         <?php if (!$fallback_mode) { ?>


### PR DESCRIPTION
The changes modify the default title and meta information. (Requested in #710)
You can now set the title and meta via the options.json file with placeholders for path and dir of the link.

Discord example:
![image](https://user-images.githubusercontent.com/54647612/107439352-3532f180-6b32-11eb-8cd4-a015516d2c1a.png)

WhatsApp example:
![image](https://user-images.githubusercontent.com/54647612/107439599-9c50a600-6b32-11eb-914c-fa7bac3197a4.png)
