### PR TITLE
fix: no prepare script causes dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "h5ai",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "h5ai",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Modern HTTP web server index.",
   "homepage": "https://larsjung.de/h5ai/",
   "author": "Lars Jung <lrsjng@gmail.com> (https://larsjung.de)",
   "license": "MIT",
+  "main": "",
   "repository": {
     "type": "git",
     "url": "https://github.com/lrsjng/h5ai.git"
   },
   "scripts": {
+    "prepare": "npm run build",
     "lint": "eslint .",
     "test": "node test",
     "build": "node ghu release",


### PR DESCRIPTION
When used as a dependency, devDependencies required to build h5ai will not be installed by npm if there is no "prepare" script per [npm docs](https://docs.npmjs.com/cli/v8/commands/npm-install).

This PR adds the required script as well as files/package.json entries that will allow the h5ai repo to be included as a npm dependency.