### PR TITLE
Fix: useBrowserLang not working for zh-cn, zh-tw, pt-pt and pt-br

### DIFF
--- a/src/_h5ai/public/js/lib/ext/l10n.js
+++ b/src/_h5ai/public/js/lib/ext/l10n.js
@@ -91,7 +91,7 @@ const localize = (languages, isoCode, useBrowserLang) => {
     if (languages[storedIsoCode]) {
         isoCode = storedIsoCode;
     } else if (useBrowserLang) {
-        const browserLang = win.navigator.language || win.navigator.browserLanguage;
+        const browserLang = win.navigator.language.toLowerCase() || win.navigator.browserLanguage.toLowerCase();
         if (browserLang) {
             if (languages[browserLang]) {
                 isoCode = browserLang;


### PR DESCRIPTION
zh-cn, zh-tw, pt-pt and pt-br does not automatically load if the browser is one of those languages if useBrowserLang is true, the reason for this is because zh-cn, zh-tw, pt-pt and pt-br all end on uppercase characters

for an example, zh-cn is zh-CN in the browser